### PR TITLE
e2e tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,11 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "args": [
+                "--disable-extensions",
+                "--extensionDevelopmentPath=${workspaceRoot}",
+                "--extensionTestsPath=${workspaceRoot}/out/test"
+            ],
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+interface TestEditorOptions {
+    language?: string;
+    content?: string;
+}
+
+type TestEditorAction = (editor: vscode.TextEditor, document: vscode.TextDocument) => void;
+
+async function inTextEditor(options: TestEditorOptions, action: TestEditorAction) {
+    const d = await vscode.workspace.openTextDocument(options);
+    await vscode.window.showTextDocument(d);
+    await action(vscode.window.activeTextEditor!, d);
+}
+
+function move(editor: vscode.TextEditor, line: number, col: number) {
+    const pos = new vscode.Position(line, col);
+    editor.selection = new vscode.Selection(pos, pos);
+}
+
+suite('Commands', () => {
+
+    test('Demote', async () => {
+        const steps = [
+            '* Home',
+            '** Home',
+            '*** Home',
+            '**** Home',
+            '***** Home',
+        ];
+
+        await inTextEditor({language: 'org', content: steps[0]}, async (e, d) => {
+            for (let i = 1; i < steps.length; ++i) {
+                await vscode.commands.executeCommand('org.doDemote');
+                assert.equal(d.getText(), steps[i]);
+            }
+        });
+    });
+
+    test('Promote', async () => {
+        const steps = [
+            '***** Home',
+            '**** Home',
+            '*** Home',
+            '** Home',
+            '* Home',
+        ];
+
+        await inTextEditor({language: 'org', content: steps[0]}, async (e, d) => {
+            for (let i = 1; i < steps.length; ++i) {
+                await vscode.commands.executeCommand('org.doPromote');
+                assert.equal(d.getText(), steps[i]);
+            }
+        });
+    });
+});

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -34,7 +34,7 @@ suite('Commands', () => {
             '***** Home',
         ];
 
-        await inTextEditor({language: 'org', content: steps[0]}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
             for (let i = 1; i < steps.length; ++i) {
                 await vscode.commands.executeCommand('org.doDemote');
                 assert.equal(d.getText(), steps[i]);
@@ -51,7 +51,7 @@ suite('Commands', () => {
             '* Home',
         ];
 
-        await inTextEditor({language: 'org', content: steps[0]}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
             for (let i = 1; i < steps.length; ++i) {
                 await vscode.commands.executeCommand('org.doPromote');
                 assert.equal(d.getText(), steps[i]);
@@ -64,7 +64,7 @@ suite('Commands', () => {
         const expected = 'Some *text* here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             select(e, textWordRange);
             await vscode.commands.executeCommand('org.bold');
             assert.equal(d.getText(), expected);
@@ -76,7 +76,7 @@ suite('Commands', () => {
         const expected = 'Some /text/ here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             select(e, textWordRange);
             await vscode.commands.executeCommand('org.italic');
             assert.equal(d.getText(), expected);
@@ -88,7 +88,7 @@ suite('Commands', () => {
         const expected = 'Some _text_ here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             select(e, textWordRange);
             await vscode.commands.executeCommand('org.underline');
             assert.equal(d.getText(), expected);
@@ -100,7 +100,7 @@ suite('Commands', () => {
         const expected = 'Some ~text~ here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             select(e, textWordRange);
             await vscode.commands.executeCommand('org.code');
             assert.equal(d.getText(), expected);
@@ -112,7 +112,7 @@ suite('Commands', () => {
         const expected = 'Some =text= here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             select(e, textWordRange);
             await vscode.commands.executeCommand('org.verbose');
             assert.equal(d.getText(), expected);
@@ -123,8 +123,23 @@ suite('Commands', () => {
         const initial = 'Some text here';
         const expected = ': Some text here';
 
-        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             await vscode.commands.executeCommand('org.literal');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('InsertSubheading', async () => {
+        const initial = `* Header
+* Header2`;
+        const expected = `* Header\n` +
+            `** \n` +
+            `*** \n` +
+            `* Header2`;
+
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+            await vscode.commands.executeCommand('org.insertSubheading');
+            await vscode.commands.executeCommand('org.insertSubheading');
             assert.equal(d.getText(), expected);
         });
     });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -36,13 +36,13 @@ suite('Commands', () => {
             '***** Home',
         ];
 
-        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
             for (let i = 1; i < steps.length; ++i) {
                 await vscode.commands.executeCommand('org.doDemote');
-                assert.equal(d.getText(), steps[i]);
+                assert.equal(document.getText(), steps[i]);
             }
         });
-    }).timeout(10000); // First test could be slow because of VSCode init
+    });
 
     test('Promote', async () => {
         const steps = [
@@ -53,10 +53,10 @@ suite('Commands', () => {
             '* Home',
         ];
 
-        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
             for (let i = 1; i < steps.length; ++i) {
                 await vscode.commands.executeCommand('org.doPromote');
-                assert.equal(d.getText(), steps[i]);
+                assert.equal(document.getText(), steps[i]);
             }
         });
     });
@@ -66,10 +66,10 @@ suite('Commands', () => {
         const expected = 'Some *text* here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
-            select(e, textWordRange);
+        await inTextEditor({ language: 'org', content: initial }, async (editor, document) => {
+            select(editor, textWordRange);
             await vscode.commands.executeCommand('org.bold');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -78,10 +78,10 @@ suite('Commands', () => {
         const expected = 'Some /text/ here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
-            select(e, textWordRange);
+        await inTextEditor({ language: 'org', content: initial }, async (editor, document) => {
+            select(editor, textWordRange);
             await vscode.commands.executeCommand('org.italic');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -90,10 +90,10 @@ suite('Commands', () => {
         const expected = 'Some _text_ here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
-            select(e, textWordRange);
+        await inTextEditor({ language: 'org', content: initial }, async (editor, document) => {
+            select(editor, textWordRange);
             await vscode.commands.executeCommand('org.underline');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -102,10 +102,10 @@ suite('Commands', () => {
         const expected = 'Some ~text~ here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
-            select(e, textWordRange);
+        await inTextEditor({ language: 'org', content: initial }, async (editor, document) => {
+            select(editor, textWordRange);
             await vscode.commands.executeCommand('org.code');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -114,10 +114,10 @@ suite('Commands', () => {
         const expected = 'Some =text= here';
         const textWordRange = new vscode.Range(0, 5, 0, 9);
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
-            select(e, textWordRange);
+        await inTextEditor({ language: 'org', content: initial }, async (editor, document) => {
+            select(editor, textWordRange);
             await vscode.commands.executeCommand('org.verbose');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -125,9 +125,9 @@ suite('Commands', () => {
         const initial = 'Some text here';
         const expected = ': Some text here';
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (_, document) => {
             await vscode.commands.executeCommand('org.literal');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -139,10 +139,10 @@ suite('Commands', () => {
             `*** \n` +
             `* Header2`;
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (_, document) => {
             await vscode.commands.executeCommand('org.insertSubheading');
             await vscode.commands.executeCommand('org.insertSubheading');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -153,10 +153,10 @@ suite('Commands', () => {
             '* DONE Header',
         ];
 
-        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
             for (let i = 1; i < steps.length; ++i) {
                 await vscode.commands.executeCommand('org.incrementContext');
-                assert.equal(d.getText(), steps[i]);
+                assert.equal(document.getText(), steps[i]);
             }
         });
     });
@@ -185,9 +185,9 @@ suite('Commands', () => {
 *** Subheader
 * Header 2`;
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (_, document) => {
             await vscode.commands.executeCommand('org.demoteSubtree');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -200,9 +200,9 @@ suite('Commands', () => {
 ** Subheader
 ** Header 2`;
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (_, document) => {
             await vscode.commands.executeCommand('org.promoteSubtree');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -215,9 +215,9 @@ suite('Commands', () => {
         const initial = '';
         const expected = `<${datePart} ${dayOfWeek}>`;
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (_, document) => {
             await vscode.commands.executeCommand('org.timestamp');
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 
@@ -241,19 +241,19 @@ suite('Commands', () => {
             '    And some more content here\n' +
             '* ';
 
-        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+        await inTextEditor({ language: 'org', content: initial }, async (editor, document) => {
             // Invoke while standing on 'Header'
             await vscode.commands.executeCommand('org.insertHeadingRespectContent');
 
             // Invoke while standing on 'Header 2'
-            move(e, 1, 0);
+            move(editor, 1, 0);
             await vscode.commands.executeCommand('org.insertHeadingRespectContent');
 
             // Invoke while standing on content of 'Header 2' section
-            move(e, 2, 0);
+            move(editor, 2, 0);
             await vscode.commands.executeCommand('org.insertHeadingRespectContent');
 
-            assert.equal(d.getText(), expected);
+            assert.equal(document.getText(), expected);
         });
     });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -19,6 +19,10 @@ function move(editor: vscode.TextEditor, line: number, col: number) {
     editor.selection = new vscode.Selection(pos, pos);
 }
 
+function select(editor: vscode.TextEditor, range: vscode.Range) {
+    editor.selection = new vscode.Selection(range.start, range.end);
+}
+
 suite('Commands', () => {
 
     test('Demote', async () => {
@@ -36,7 +40,7 @@ suite('Commands', () => {
                 assert.equal(d.getText(), steps[i]);
             }
         });
-    });
+    }).timeout(10000); // First test could be slow because of VSCode init
 
     test('Promote', async () => {
         const steps = [
@@ -52,6 +56,76 @@ suite('Commands', () => {
                 await vscode.commands.executeCommand('org.doPromote');
                 assert.equal(d.getText(), steps[i]);
             }
+        });
+    });
+
+    test('Bold', async () => {
+        const initial = 'Some text here';
+        const expected = 'Some *text* here';
+        const textWordRange = new vscode.Range(0, 5, 0, 9);
+
+        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+            select(e, textWordRange);
+            await vscode.commands.executeCommand('org.bold');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Italic', async () => {
+        const initial = 'Some text here';
+        const expected = 'Some /text/ here';
+        const textWordRange = new vscode.Range(0, 5, 0, 9);
+
+        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+            select(e, textWordRange);
+            await vscode.commands.executeCommand('org.italic');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Underline', async () => {
+        const initial = 'Some text here';
+        const expected = 'Some _text_ here';
+        const textWordRange = new vscode.Range(0, 5, 0, 9);
+
+        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+            select(e, textWordRange);
+            await vscode.commands.executeCommand('org.underline');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Code', async () => {
+        const initial = 'Some text here';
+        const expected = 'Some ~text~ here';
+        const textWordRange = new vscode.Range(0, 5, 0, 9);
+
+        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+            select(e, textWordRange);
+            await vscode.commands.executeCommand('org.code');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Verbose', async () => {
+        const initial = 'Some text here';
+        const expected = 'Some =text= here';
+        const textWordRange = new vscode.Range(0, 5, 0, 9);
+
+        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+            select(e, textWordRange);
+            await vscode.commands.executeCommand('org.verbose');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Literal', async () => {
+        const initial = 'Some text here';
+        const expected = ': Some text here';
+
+        await inTextEditor({language: 'org', content: initial}, async (e, d) => {
+            await vscode.commands.executeCommand('org.literal');
+            assert.equal(d.getText(), expected);
         });
     });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -143,4 +143,34 @@ suite('Commands', () => {
             assert.equal(d.getText(), expected);
         });
     });
+
+    test('IncrementContext', async () => {
+        const steps = [
+            '* Header',
+            '* TODO Header',
+            '* DONE Header',
+        ];
+
+        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
+            for (let i = 1; i < steps.length; ++i) {
+                await vscode.commands.executeCommand('org.incrementContext');
+                assert.equal(d.getText(), steps[i]);
+            }
+        });
+    });
+
+    test('DecrementContext', async () => {
+        const steps = [
+            '* DONE Header',
+            '* TODO Header',
+            '* Header',
+        ];
+
+        await inTextEditor({ language: 'org', content: steps[0] }, async (e, d) => {
+            for (let i = 1; i < steps.length; ++i) {
+                await vscode.commands.executeCommand('org.decrementContext');
+                assert.equal(d.getText(), steps[i]);
+            }
+        });
+    });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -173,4 +173,34 @@ suite('Commands', () => {
             }
         });
     });
+
+    test('DemoteSubtree', async () => {
+        const initial = `* Header 1
+** Subheader
+* Header 2`;
+
+        const expected = `** Header 1
+*** Subheader
+* Header 2`;
+
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+            await vscode.commands.executeCommand('org.demoteSubtree');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('PromoteSubtree', async () => {
+        const initial = `** Header 1
+*** Subheader
+** Header 2`;
+
+        const expected = `* Header 1
+** Subheader
+** Header 2`;
+
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+            await vscode.commands.executeCommand('org.promoteSubtree');
+            assert.equal(d.getText(), expected);
+        });
+    });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -23,6 +23,8 @@ function select(editor: vscode.TextEditor, range: vscode.Range) {
     editor.selection = new vscode.Selection(range.start, range.end);
 }
 
+const weekdayArray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 suite('Commands', () => {
 
     test('Demote', async () => {
@@ -200,6 +202,21 @@ suite('Commands', () => {
 
         await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             await vscode.commands.executeCommand('org.promoteSubtree');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Timestamp', async () => {
+        // TODO: Need to find a way to somehow mock Date
+        const now = new Date();
+        const datePart = now.toISOString().slice(0, 10);
+        const dayOfWeek = weekdayArray[now.getDay()];
+
+        const initial = '';
+        const expected = `<${datePart} ${dayOfWeek}>`;
+
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+            await vscode.commands.executeCommand('org.timestamp');
             assert.equal(d.getText(), expected);
         });
     });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -220,4 +220,40 @@ suite('Commands', () => {
             assert.equal(d.getText(), expected);
         });
     });
+
+    test('Insert Heading Respect Content', async () => {
+        const initial = '* Header\n' +
+            '** Header 2\n' +
+            '    Some content goes here\n' +
+            '*** Header 3\n' +
+            '    Some more content that goes here\n' +
+            '** Header again\n' +
+            '    And some more content here';
+
+        const expected = '* Header\n' +
+            '** Header 2\n' +
+            '    Some content goes here\n' +
+            '*** Header 3\n' +
+            '    Some more content that goes here\n' +
+            '** \n' +
+            '** \n' +
+            '** Header again\n' +
+            '    And some more content here\n' +
+            '* ';
+
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+            // Invoke while standing on 'Header'
+            await vscode.commands.executeCommand('org.insertHeadingRespectContent');
+
+            // Invoke while standing on 'Header 2'
+            move(e, 1, 0);
+            await vscode.commands.executeCommand('org.insertHeadingRespectContent');
+
+            // Invoke while standing on content of 'Header 2' section
+            move(e, 2, 0);
+            await vscode.commands.executeCommand('org.insertHeadingRespectContent');
+
+            assert.equal(d.getText(), expected);
+        });
+    });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -23,6 +23,8 @@ function select(editor: vscode.TextEditor, range: vscode.Range) {
     editor.selection = new vscode.Selection(range.start, range.end);
 }
 
+const weekdayArray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 suite('Commands', () => {
 
     test('Demote', async () => {
@@ -200,6 +202,20 @@ suite('Commands', () => {
 
         await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
             await vscode.commands.executeCommand('org.promoteSubtree');
+            assert.equal(d.getText(), expected);
+        });
+    });
+
+    test('Timestamp', async () => {
+        const now = new Date();
+        const datePart = now.toISOString().slice(0, 10);
+        const dayOfWeek = weekdayArray[now.getDay()];
+
+        const initial = '';
+        const expected = `<${datePart} ${dayOfWeek}>`;
+
+        await inTextEditor({ language: 'org', content: initial }, async (e, d) => {
+            await vscode.commands.executeCommand('org.timestamp');
             assert.equal(d.getText(), expected);
         });
     });


### PR DESCRIPTION
This pull request contains basic e2e tests for almost all commands currently available in the extension.

Tests for commands like clockIn, clockOut and updateClock were skipped, because those commands are in very early stage (comparing to Emacs) and may even need rewrite.